### PR TITLE
Fix assorted typographical and minor errors.

### DIFF
--- a/01_background.tex
+++ b/01_background.tex
@@ -11,7 +11,7 @@ Then $ \nabla f = \ba.$ That is, the function that
 contains the elementwise derivatives of $f$ (the gradient)
 is constant with respect to $x$. 
 
-Consider now the matrix $\bA$
+Consider now the symmetric matrix $\bA$
 ($p\times p$) and the quadratic form:
 $$
 f(\bx) =  \bx^t \bA \bx.
@@ -28,13 +28,13 @@ Let $\by$ be an array of dimension $n\times 1$ and
 $\bX$ be an $n\times p$ full rank matrix. Let $\bbeta$ be a
 $p$ vector of unknowns. Consider trying to minimize the function:
 $$
-f(\bbeta) = ||\by - \bbeta \bX||^2 = (\by - \bbeta \bX)^t (\by - \bbeta \bX)
-= \by^t \by - 2 \by^t \bX^t \bbeta + \bbeta^t \bX^t \bX \bbeta.
+f(\bbeta) = ||\by - \bX \bbeta||^2 = (\by - \bX \bbeta)^t (\by - \bX \bbeta)
+= \by^t \by - 2 \by^t \bX \bbeta + \bbeta^t \bX^t \bX \bbeta.
 $$
 The gradient of $f$ (with respect to $\bbeta$) is:
 \begin{equation}
 \label{eq:deriv}
-\nabla f(\bbeta) = -2 \bX \by + \bX^t\bX \bbeta.
+\nabla f(\bbeta) = -2 \bX^t \by + 2 \bX^t\bX \bbeta.
 \end{equation}
 A useful result is that if $\bX$ is of full column rank then
 $\bX^t \bX$ is square and full rank and hence invertible. Thus, we can
@@ -48,7 +48,7 @@ inflection point. We can do this by checking a second derivative
 condition. Taking the second derivative of \eqref{eq:deriv} we 
 get
 $$
-\bX^t\bX,
+2 \bX^t\bX,
 $$
 a positive definite matrix. Thus our solution is indeed a minimum.
 
@@ -165,7 +165,7 @@ R functions.
 
 
 Consider the fact that the matrix $\left\{ \bI - \bone_n (\bone_n^t \bone_n)^{-1} \bone_n^t \right\}$
-is both symmetric and idempotent. The standard sample variance is the average deviation of the
+is both symmetric and idempotent. The standard sample variance is the average squared deviation of the
 observations from the sample mean (usually using $n-1$ rather than $n$). That is,
 $$
 S^2 = \frac{1}{n-1}|| \by - \bar y \bone_n ||^2 = \frac{1}{n-1} \tilde \by^t \tilde \by
@@ -178,7 +178,7 @@ $$
 $$
 Thus, our sample variance is a fairly simple quadratic form. 
 
-Similarly, if we have two vectors, $\by$ and $\bz$ then $\frac{1}{n-1}\by \left\{ \bI - \bone_n (\bone_n^t \bone_n)^{-1} \bone_n^t \right\} \bz$ is the
+Similarly, if we have two vectors, $\by$ and $\bz$ then $\frac{1}{n-1}\by^t \left\{ \bI - \bone_n (\bone_n^t \bone_n)^{-1} \bone_n^t \right\} \bz$ is the
 empirical correlation between them.
 This is then useful for matrices. Consider that
 $$
@@ -186,7 +186,7 @@ $$
 = \frac{1}{n-1} \tilde \bX^t \tilde \bX
 $$
 is a matrix where each element is the empirical covariance between columns of $\bX$.
-This is called the variance/covariation matrix. 
+This is called the variance-covariance matrix. 
 
 \subsection{Coding example}
 

--- a/02_single_parameter.tex
+++ b/02_single_parameter.tex
@@ -10,7 +10,7 @@ $
 \by = (y_1,\ldots, y_n)^t
 $ and recall that $\bone_n$ is an $n$ vector of ones. We want
 to minimize 
-$f(\mu) = ||\by - \mu \bone||^2$ with respect to $\mu$. 
+${f(\mu) = ||\by - \mu \bone_n||^2}$ with respect to $\mu$. 
 
 Taking derivatives with respect to $\mu$ we obtain that
 $$
@@ -21,8 +21,8 @@ derivative is $2n>0$.
 Thus, the average is the least squares estimate in the
 sense of minimizing the Euclidean distance between the
 observed data and a constant vector. We can think of this
-as projecting our $n$ dimensional onto the best $1$
-dimensional subspace spanned by the vector $\bone$. We'll
+as projecting our $n$ dimensional vector $\by$ onto the best $1$
+dimensional subspace spanned by the vector $\bone_n$. We'll
 rely on this form of thinking a lot throughout the text.
 
 \section{Coding example}
@@ -98,14 +98,14 @@ $
 $
 However, from the previous chapter, we know that
 $$
-\ip{\tilde \by}{\tilde \bx} = \by^t \left\{ \bI - \bone_n (\bone_n^t \bone_n)^{-1} \bone_n^t \right\} \bx^t
-= (n-1)\hat{\rho}_{xy} \sigma_x \sigma_y
+\ip{\tilde \by}{\tilde \bx} = \by^t \left\{ \bI - \bone_n (\bone_n^t \bone_n)^{-1} \bone_n^t \right\} \bx
+= (n-1)\hat{\rho}_{xy} \hat{\sigma}_x \hat{\sigma}_y
 $$
-and similarly $\ip{\tilde \bx}{\tilde \bx} = (n-1)\hat{\sigma}_y^2$
-where $\hat \rho_{xy}$ and $\hat{\sigma}_y^2$ are the empirical correlation and
+and similarly $\ip{\tilde \bx}{\tilde \bx} = (n-1)\hat{\sigma}_x^2$
+where $\hat \rho_{xy}$ and $\hat{\sigma}_x^2$ are the empirical correlation and
 variance, respectively. Thus our regression through the origin estimate is
 $$
-\hat \gamma = \rho_{xy} \frac{\sigma_y}{\sigma_x}.
+\hat \gamma = \hat{\rho}_{xy} \frac{\hat{\sigma}_y}{\hat{\sigma}_x}.
 $$
 Thus the best fitting line that has to go through the center of the data
 has a slope equal to the correlation times the ratio of the standard deviations.
@@ -134,7 +134,7 @@ Let's continue with the diamond example. We'll center the variables first.
 \section{Bonus videos}
 
 \noindent
-Watch these videos before moving on. (I had created them beofre I reorganized chapters.)
+Watch these videos before moving on. (I had created them before I reorganized chapters.)
 
 \href{https://www.youtube.com/watch?v=lmv88DtCNiU&list=PLpl-gQkQivXhdgUCdaUQcdb31CRe8Mm2y&index=10}{Sneak preview of projection logic.}
 

--- a/04_least_squares.tex
+++ b/04_least_squares.tex
@@ -100,10 +100,10 @@ is going to give us a larger norm than if we plug in $\hat \beta$ so that
 it is the unique minimum.
 Notice that going from line 5 to 6, we used the fact that $\bI - \hatmat$ is symmetric. (It is also idempotent.) Also, we used a fact that is very
 useful in general, $\bI - \hatmat$ is orthogonal to any linear combination
-of the columns of $\bX$. This is try since if $\bX \ba$ is such a combination,
+of the columns of $\bX$. This is true since if $\bX \ba$ is such a combination,
 then
 $$
-\{\bI - \hatmat)\}bX \ba = \{\bX - \hatmat \bX\}\ba = (\bX - \bX) \ba = 0.
+\{\bI - \hatmat)\}\bX \ba = \{\bX - \hatmat \bX\}\ba = (\bX - \bX) \ba = 0.
 $$
 This fact is extremely handy in working with linear models. 
 

--- a/07_residuals.tex
+++ b/07_residuals.tex
@@ -19,7 +19,7 @@ expanding the column space of $\bX$ by adding any new
 linearly indpendent variables, the normal of the residuals
 must decrease. In other words, if we add any non-redundant
 regressors, we necessarily remove residual variability. Furthermore,
-as we already know, $\bX$ is of full column rank, then our residuals
+as we already know, if $\bX$ is of full column rank, then our residuals
 are all zero, since $\by = \hat \by$. 
 
  Notice that the residuals are equal to:


### PR DESCRIPTION
Dr. Caffo --

I'm a mentor for the Coursera Adv Linear Models 1 course.  Several students pointed out the word "symmetric" is missing in the text, so I've added that, plus tweaked several other little typos.  I've checked that this can still be built with pdflatex.  These are the changes.

In the ch. 2 background section, does not say A is symmetric.  (The corresponding lecture does.)  One discussion thread on this is here:
https://www.coursera.org/learn/linear-models/discussions/weeks/1/threads/ATanir2iEeevSwpBtQ053g?sort=createdAtDesc
The line this is in is:
https://github.com/bcaffo/lm/blob/master/01_background.tex#L14

Sec 2.1, f(\beta) expansion should have X \beta rather than \beta X or X^t \beta.  There are two missing 2s.  Discussion is here:
https://www.coursera.org/learn/linear-models/discussions/forums/8GYS9hlTEeaVGhJkV5uBJw/threads/JwrxIsykEeaLXA6EMuj8Jg
https://github.com/bcaffo/lm/blob/master/01_background.tex#L31
https://github.com/bcaffo/lm/blob/master/01_background.tex#L37
https://github.com/bcaffo/lm/blob/master/01_background.tex#L51

Sec 2.4, should say "average squared deviation".
https://github.com/bcaffo/lm/blob/master/01_background.tex#L168

Sec 2.4, in empirical correlation of y and z, y is missing transpose.
https://github.com/bcaffo/lm/blob/master/01_background.tex#L181

Sec 2.4:  variance/covariation matrix -> variance-covariance matrix.
https://github.com/bcaffo/lm/blob/master/01_background.tex#L189

Sec 3.1, missing words:
"We can think of this as projecting our n dimensional [vector y] onto the best 1 dimensional subspace spanned by the vector 1."
https://github.com/bcaffo/lm/blob/master/02_single_parameter.tex#L24

Sec 3.1, says 1_n will be the vector of n 1s, but then omits the n in a few places.  (It's consistently used elsewhere.)
https://github.com/bcaffo/lm/blob/master/02_single_parameter.tex#L13
https://github.com/bcaffo/lm/blob/master/02_single_parameter.tex#L25
Note fixing the first of those caused a line break in the middle of an equation, so I put { } around it.  That causes it not to be broken, but it makes the line a bit too long.

Sec 3.4, The <y~, x~> equation has x^t rather than x at the end.
https://github.com/bcaffo/lm/blob/master/02_single_parameter.tex#L101

Sec 3.4, Some of the rhos & sigmas don't have hats.
https://github.com/bcaffo/lm/blob/master/02_single_parameter.tex#L102
https://github.com/bcaffo/lm/blob/master/02_single_parameter.tex#L108

Sec 3.4, <x~, x~> is given as sigma_y^2 rather than sigma_x^2.
https://github.com/bcaffo/lm/blob/master/02_single_parameter.tex#L101

Sec 3.5, beofre -> before.
https://github.com/bcaffo/lm/blob/master/02_single_parameter.tex#L137

Sec 5.2, try -> true.
https://github.com/bcaffo/lm/blob/master/04_least_squares.tex#L103

Sec 5.2, A spurious "b" appears in the last equation -- it is supposed to be markup for bold.
https://github.com/bcaffo/lm/blob/master/04_least_squares.tex#L103

Sec 8.1, 2nd paragraph says "...as we already know, X is of full column rank, then...".  Believe this is missing the word "if", i.e. should say, "...as we already know, if X is of full column rank, then...".
https://github.com/bcaffo/lm/blob/master/07_residuals.tex#L22
